### PR TITLE
sm8250-common: Add vendor.nxp.nxpnfc_aidl.INxpNfc/default

### DIFF
--- a/framework_compatibility_matrix.xml
+++ b/framework_compatibility_matrix.xml
@@ -7,6 +7,14 @@
             <instance>default</instance>
         </interface>
     </hal>
+   <hal format="aidl" optional="true">
+        <name>vendor.nxp.nxpnfc_aidl</name>
+        <version>1</version>
+        <interface>
+            <name>INxpNfc</name>
+            <instance>default</instance>
+        </interface>
+    </hal>
     <hal format="aidl" optional="true">
         <name>android.hardware.bluetooth.audio</name>
         <version>2</version>


### PR DESCRIPTION
ERROR: files are incompatible: The following instances are in the device manifest but not specified in framework compatibility matrix:                                                                      vendor.nxp.nxpnfc_aidl.INxpNfc/default (@1)

Change-Id: I15696723afdac3074e96271c0be6c7f19bbed232